### PR TITLE
Auth + RBAC + Employee module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ EMAIL_ADMIN=your_admin_email
 EMAIL_EMPLOYEE=your_employee_email
 ADMIN_PASSWORD=your_admin_password
 EMPLOYEE_PASSWORD=your_employee_password
+
+# COOKIES
+# COOKIES
+COOKIE_DOMAIN=your_cookie_domain
+COOKIE_SAME_SITE=your_cookie_same_site
+COOKIE_SECURE=true_or_false_based_on_your_environment

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ DB_PORT=your_database_port
 DB_USERNAME=your_database_username
 DB_PASSWORD=your_database_password
 DB_NAME=your_database_name
+
+# Seed Users Credentials
+EMAIL_ADMIN=your_admin_email
+EMAIL_EMPLOYEE=your_employee_email
+ADMIN_PASSWORD=your_admin_password
+EMPLOYEE_PASSWORD=your_employee_password

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "seed": "ts-node ./scripts/rbac.seeder.ts",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
@@ -28,6 +29,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "dotenv": "^17.2.2",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      dotenv:
+        specifier: ^17.2.2
+        version: 17.2.2
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -1665,9 +1668,6 @@ packages:
         integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==,
       }
 
-  axios@1.12.2:
-    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
-
   babel-jest@29.7.0:
     resolution:
       {
@@ -1793,9 +1793,6 @@ packages:
         integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
       }
 
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
   buffer-from@1.1.2:
     resolution:
       {
@@ -1813,9 +1810,6 @@ packages:
       {
         integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==,
       }
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   busboy@1.6.0:
     resolution:
@@ -2167,10 +2161,6 @@ packages:
       }
     engines: { node: '>= 0.6' }
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   cookiejar@2.1.4:
     resolution:
       {
@@ -2245,9 +2235,6 @@ packages:
         integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==,
       }
 
-  cross-fetch@3.2.0:
-    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
-
   cross-spawn@7.0.6:
     resolution:
       {
@@ -2261,9 +2248,6 @@ packages:
         integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==,
       }
 
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-
   dargs@8.1.0:
     resolution:
       {
@@ -2276,9 +2260,6 @@ packages:
       {
         integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==,
       }
-
-  dayjs@1.11.18:
-    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
   debug@2.6.9:
     resolution:
@@ -2430,17 +2411,12 @@ packages:
       }
     engines: { node: '>=12' }
 
-  dotenv-expand@12.0.1:
-    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
-    engines: {node: '>=12'}
-
-  dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
+  dotenv@17.2.2:
+    resolution:
+      {
+        integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==,
+      }
+    engines: { node: '>=12' }
 
   dunder-proto@1.0.1:
     resolution:
@@ -2460,9 +2436,6 @@ packages:
       {
         integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
       }
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution:
@@ -2920,15 +2893,6 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   foreground-child@3.3.1:
     resolution:
       {
@@ -3206,10 +3170,6 @@ packages:
         integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==,
       }
     engines: { node: '>= 6' }
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   human-signals@2.1.0:
     resolution:
@@ -3725,7 +3685,7 @@ packages:
     resolution:
       {
         integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==,
-      
+      }
 
   js-tokens@4.0.0:
     resolution:
@@ -3837,16 +3797,6 @@ packages:
         integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==,
       }
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
-    engines: {node: '>=12', npm: '>=6'}
-
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
-
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
-
   keyv@4.5.4:
     resolution:
       {
@@ -3879,9 +3829,6 @@ packages:
       {
         integrity: sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==,
       }
-
-  libphonenumber-js@1.12.23:
-    resolution: {integrity: sha512-RN3q3gImZ91BvRDYjWp7ICz3gRn81mW5L4SW+2afzNCC0I/nkXstBgZThQGTE3S/9q5J90FH4dP+TXx8NhdZKg==}
 
   lines-and-columns@1.2.4:
     resolution:
@@ -3962,18 +3909,6 @@ packages:
         integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==,
       }
 
-  lodash.includes@4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isboolean@3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-
-  lodash.isinteger@4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-
-  lodash.isnumber@3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-
   lodash.isplainobject@4.0.6:
     resolution:
       {
@@ -3985,9 +3920,6 @@ packages:
       {
         integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
       }
-
-  lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.kebabcase@4.1.1:
     resolution:
@@ -4018,9 +3950,6 @@ packages:
       {
         integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
       }
-
-  lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.snakecase@4.1.1:
     resolution:
@@ -4343,10 +4272,6 @@ packages:
       }
     engines: { node: '>=6.0.0' }
 
-  nodemailer@6.10.1:
-    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
-    engines: {node: '>=6.0.0'}
-
   normalize-path@3.0.0:
     resolution:
       {
@@ -4483,9 +4408,6 @@ packages:
       {
         integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==,
       }
-
-  pako@2.1.0:
-    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   parent-module@1.0.1:
     resolution:
@@ -4667,9 +4589,6 @@ packages:
         integrity: sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==,
       }
 
-  pkce-challenge@3.1.0:
-    resolution: {integrity: sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==}
-
   pkg-dir@4.2.0:
     resolution:
       {
@@ -4755,10 +4674,6 @@ packages:
       }
     engines: { node: '>= 0.6.0' }
 
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
   prompts@2.4.2:
     resolution:
       {
@@ -4778,9 +4693,6 @@ packages:
       {
         integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
       }
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution:
@@ -4814,9 +4726,6 @@ packages:
       {
         integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==,
       }
-
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution:
@@ -4896,9 +4805,6 @@ packages:
       {
         integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==,
       }
-
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-cwd@3.0.0:
     resolution:
@@ -5035,9 +4941,6 @@ packages:
         integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==,
       }
 
-  scmp@2.1.0:
-    resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}
-
   semver@6.3.1:
     resolution:
       {
@@ -5078,9 +4981,6 @@ packages:
       {
         integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==,
       }
-
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution:
@@ -5391,25 +5291,6 @@ packages:
         integrity: sha512-cCuY9Y5Mj93Pg1ktbqilouWgAoQWniQauftB4Ef6rfOchogx13XTo1pNP14zezn2rSf7WIPb9iaZb5zif6TKtQ==,
       }
 
-  supertokens-js-override@0.0.4:
-    resolution: {integrity: sha512-r0JFBjkMIdep3Lbk3JA+MpnpuOtw4RSyrlRAbrzMcxwiYco3GFWl/daimQZ5b1forOiUODpOlXbSOljP/oyurg==}
-
-  supertokens-nestjs@0.0.5:
-    resolution: {integrity: sha512-AO+nVPQDXwZKqxwz1vM1NWeesCec8nip06Agu6GBG0qXjYB7RN7y0pelbRlZkXvaqD8zHU0wsQZLoG3sLxzztw==}
-    peerDependencies:
-      '@nestjs/core': ^11.0.1
-      '@nestjs/platform-express': ^11.0.1
-      '@nestjs/platform-fastify': ^11.0.6
-      supertokens-node: ^21.1.0 || ^22.1.0
-    peerDependenciesMeta:
-      '@nestjs/platform-express':
-        optional: true
-      '@nestjs/platform-fastify':
-        optional: true
-
-  supertokens-node@23.0.1:
-    resolution: {integrity: sha512-cCuY9Y5Mj93Pg1ktbqilouWgAoQWniQauftB4Ef6rfOchogx13XTo1pNP14zezn2rSf7WIPb9iaZb5zif6TKtQ==}
-
   supports-color@7.2.0:
     resolution:
       {
@@ -5522,13 +5403,6 @@ packages:
       {
         integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==,
       }
-    hasBin: true
-
-  tldts-core@6.1.86:
-    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
-
-  tldts@6.1.86:
-    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
   tmp@0.0.33:
@@ -5677,10 +5551,6 @@ packages:
         integrity: sha512-LdNBQfOe0dY2oJH2sAsrxazpgfFQo5yXGxe96QA8UWB5uu+433PrUbkv8gQ5RmrRCqUTPQ0aOrIyAdBr1aB03Q==,
       }
     engines: { node: '>=14.0' }
-
-  twilio@4.23.0:
-    resolution: {integrity: sha512-LdNBQfOe0dY2oJH2sAsrxazpgfFQo5yXGxe96QA8UWB5uu+433PrUbkv8gQ5RmrRCqUTPQ0aOrIyAdBr1aB03Q==}
-    engines: {node: '>=14.0'}
 
   type-check@0.4.0:
     resolution:
@@ -5882,9 +5752,6 @@ packages:
         integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==,
       }
 
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
-
   util-deprecate@1.0.2:
     resolution:
       {
@@ -6065,10 +5932,6 @@ packages:
         integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==,
       }
     engines: { node: '>=6.0' }
-
-  xmlbuilder@13.0.2:
-    resolution: {integrity: sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==}
-    engines: {node: '>=6.0'}
 
   xtend@4.0.2:
     resolution:
@@ -7758,6 +7621,8 @@ snapshots:
   dotenv@16.4.7: {}
 
   dotenv@16.6.1: {}
+
+  dotenv@17.2.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/scripts/rbac.seeder.ts
+++ b/scripts/rbac.seeder.ts
@@ -19,6 +19,10 @@ const { EMAIL_ADMIN, EMAIL_EMPLOYEE, ADMIN_PASSWORD, EMPLOYEE_PASSWORD } =
 // SuperTokens configuration
 const { CONNECTION_URI, APP_NAME, API_DOMAIN, WEBSITE_DOMAIN } = process.env;
 
+if (!EMAIL_ADMIN || !EMAIL_EMPLOYEE || !ADMIN_PASSWORD || !EMPLOYEE_PASSWORD) {
+  console.error('Missing seed credentials in environment variables');
+  process.exit(1);
+}
 console.log('Starting RBAC seeder...');
 
 const DumiDataSource = new DataSource({

--- a/scripts/rbac.seeder.ts
+++ b/scripts/rbac.seeder.ts
@@ -1,0 +1,108 @@
+import SuperTokens from 'supertokens-node';
+import UserRoles from 'supertokens-node/recipe/userroles';
+import EmailPassword from 'supertokens-node/recipe/emailpassword';
+import Session from 'supertokens-node/recipe/session';
+import { DataSource } from 'typeorm';
+import { ROLES } from '../src/auth/constants/roles';
+import { EmployeeEntity } from '../src/employee/entities/employee.entitiy';
+
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
+
+// Database connection configuration
+const { DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_NAME } = process.env;
+// Seed users credentials
+const { EMAIL_ADMIN, EMAIL_EMPLOYEE, ADMIN_PASSWORD, EMPLOYEE_PASSWORD } =
+  process.env;
+// SuperTokens configuration
+const { CONNECTION_URI, APP_NAME, API_DOMAIN, WEBSITE_DOMAIN } = process.env;
+
+console.log('Starting RBAC seeder...');
+
+const DumiDataSource = new DataSource({
+  type: 'postgres',
+  host: DB_HOST || 'localhost',
+  port: DB_PORT ? parseInt(DB_PORT) : 5432,
+  username: DB_USERNAME,
+  password: DB_PASSWORD,
+  database: DB_NAME,
+  entities: [EmployeeEntity],
+  synchronize: true,
+  logging: true,
+});
+
+async function main() {
+  SuperTokens.init({
+    framework: 'express',
+    supertokens: { connectionURI: CONNECTION_URI || 'http://localhost:3567' },
+    appInfo: {
+      appName: APP_NAME || 'DUMI',
+      apiDomain: API_DOMAIN || 'http://localhost:3000',
+      websiteDomain: WEBSITE_DOMAIN || 'http://localhost:3001',
+    },
+    recipeList: [EmailPassword.init(), Session.init(), UserRoles.init()],
+  });
+
+  try {
+    await DumiDataSource.initialize();
+    console.log('Data Source has been initialized!');
+  } catch (error) {
+    console.error('Error initializing data source:', error);
+    process.exit(1);
+  }
+  try {
+    await Promise.all(
+      Object.entries(ROLES).map(([role, perms]) =>
+        UserRoles.createNewRoleOrAddPermissions(role, perms),
+      ),
+    );
+    console.log('Roles and permissions seeded successfully');
+  } catch (error) {
+    console.error('Error seeding roles and permissions:', error);
+    process.exit(1);
+  }
+
+  try {
+    const signUpSeedUserResponse = await Promise.all([
+      EmailPassword.signUp('public', EMAIL_ADMIN, ADMIN_PASSWORD),
+      EmailPassword.signUp('public', EMAIL_EMPLOYEE, EMPLOYEE_PASSWORD),
+    ]);
+
+    if (
+      signUpSeedUserResponse.some(
+        (res) => res.status === 'EMAIL_ALREADY_EXISTS_ERROR',
+      )
+    ) {
+      throw new Error(
+        'User(s) already exists, seed script should be run only once',
+      );
+    }
+
+    for (const res of signUpSeedUserResponse) {
+      if (res.status === 'OK') {
+        const userId = res.user.id;
+        if (!userId) throw new Error('No user id returned by SuperTokens');
+        const user = DumiDataSource.getRepository(EmployeeEntity).create({
+          names: 'Seed User',
+          lastNames: 'Last Name',
+          email: res.user.emails[0],
+        });
+        await DumiDataSource.getRepository(EmployeeEntity).save(user);
+      }
+    }
+
+    console.log('Default users created successfully');
+  } catch (e) {
+    console.error('Error creating default users:', e);
+    process.exit(1);
+  }
+
+  console.log('RBAC seeded OK');
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/rbac.seeder.ts
+++ b/scripts/rbac.seeder.ts
@@ -3,7 +3,7 @@ import UserRoles from 'supertokens-node/recipe/userroles';
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import Session from 'supertokens-node/recipe/session';
 import { DataSource } from 'typeorm';
-import { ROLES } from '../src/auth/constants/roles';
+import { ROLE_NAMES, ROLES } from '../src/auth/constants/roles';
 import { EmployeeEntity } from '../src/employee/entities/employee.entitiy';
 
 import * as dotenv from 'dotenv';
@@ -83,12 +83,20 @@ async function main() {
       if (res.status === 'OK') {
         const userId = res.user.id;
         if (!userId) throw new Error('No user id returned by SuperTokens');
+
         const user = DumiDataSource.getRepository(EmployeeEntity).create({
           names: 'Seed User',
           lastNames: 'Last Name',
           email: res.user.emails[0],
         });
-        await DumiDataSource.getRepository(EmployeeEntity).save(user);
+        await Promise.all([
+          await DumiDataSource.getRepository(EmployeeEntity).save(user),
+          await UserRoles.addRoleToUser(
+            'public',
+            userId,
+            user.email === EMAIL_ADMIN ? ROLE_NAMES.ADMIN : ROLE_NAMES.USER,
+          ),
+        ]);
       }
     }
 

--- a/scripts/rbac.seeder.ts
+++ b/scripts/rbac.seeder.ts
@@ -2,14 +2,15 @@ import SuperTokens from 'supertokens-node';
 import UserRoles from 'supertokens-node/recipe/userroles';
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import Session from 'supertokens-node/recipe/session';
+import UserMetadata from 'supertokens-node/recipe/usermetadata';
 import { DataSource } from 'typeorm';
 import { ROLE_NAMES, ROLES } from '../src/auth/constants/roles';
 import { EmployeeEntity } from '../src/employee/entities/employee.entitiy';
 
 import * as dotenv from 'dotenv';
+import { APP_USER_ID_METADATA_KEY } from '../src/auth/constants/app-user-id-key';
 
 dotenv.config({ path: '.env.local' });
-
 // Database connection configuration
 const { DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_NAME } = process.env;
 // Seed users credentials
@@ -41,7 +42,12 @@ async function main() {
       apiDomain: API_DOMAIN || 'http://localhost:3000',
       websiteDomain: WEBSITE_DOMAIN || 'http://localhost:3001',
     },
-    recipeList: [EmailPassword.init(), Session.init(), UserRoles.init()],
+    recipeList: [
+      EmailPassword.init(),
+      Session.init(),
+      UserRoles.init(),
+      UserMetadata.init(),
+    ],
   });
 
   try {
@@ -89,14 +95,18 @@ async function main() {
           lastNames: 'Last Name',
           email: res.user.emails[0],
         });
-        await Promise.all([
-          await DumiDataSource.getRepository(EmployeeEntity).save(user),
-          await UserRoles.addRoleToUser(
+        const [appUser] = await Promise.all([
+          DumiDataSource.getRepository(EmployeeEntity).save(user),
+          UserRoles.addRoleToUser(
             'public',
             userId,
-            user.email === EMAIL_ADMIN ? ROLE_NAMES.ADMIN : ROLE_NAMES.USER,
+            user.email === EMAIL_ADMIN ? ROLE_NAMES.ADMIN : ROLE_NAMES.SELLER,
           ),
         ]);
+
+        await UserMetadata.updateUserMetadata(userId, {
+          [APP_USER_ID_METADATA_KEY]: appUser.id,
+        });
       }
     }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { CustomerModule } from './customer/customer.module';
+import { EmployeeModule } from './employee/employee.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { CustomerModule } from './customer/customer.module';
     ConfigModule,
     AuthModule,
     CustomerModule,
+    EmployeeModule,
   ],
 
   controllers: [AppController],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,8 @@ import { SuperTokensModule } from 'supertokens-nestjs';
 import UserRoles from 'supertokens-node/recipe/userroles';
 import { buildEmailPasswordRecipe } from './recipes/email-password.recipe';
 import { buildSessionRecipe } from './recipes/session.recipe';
+import UserMetadata from 'supertokens-node/recipe/usermetadata';
+
 @Module({
   imports: [
     SuperTokensModule.forRootAsync({
@@ -20,6 +22,7 @@ import { buildSessionRecipe } from './recipes/session.recipe';
           buildEmailPasswordRecipe({ employeeService }),
           buildSessionRecipe({ config: configService }),
           UserRoles.init(),
+          UserMetadata.init(),
         ],
       }),
     }),

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,9 @@ import { ConfigService } from '@nestjs/config';
 import { EmployeeModule } from 'src/employee/employee.module';
 import { EmployeeService } from 'src/employee/employee.service';
 import { SuperTokensModule } from 'supertokens-nestjs';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
-import Session from 'supertokens-node/recipe/session';
 import UserRoles from 'supertokens-node/recipe/userroles';
+import { buildEmailPasswordRecipe } from './recipes/email-password.recipe';
+import { buildSessionRecipe } from './recipes/session.recipe';
 @Module({
   imports: [
     SuperTokensModule.forRootAsync({
@@ -17,29 +17,8 @@ import UserRoles from 'supertokens-node/recipe/userroles';
       ) => ({
         ...configService.get('supertokens'),
         recipeList: [
-          EmailPassword.init({
-            override: {
-              functions: (orig) => ({
-                ...orig,
-                signUp: async (input) => {
-                  const res = await orig.signUp(input);
-                  if (res.status === 'OK') {
-                    await employeeService.createEmployee({
-                      email: res.user.emails[0],
-                    });
-                  }
-                  // TODO!:delete user if could not create employee
-                  return res;
-                },
-              }),
-            },
-          }),
-          Session.init({
-            getTokenTransferMethod: () => 'cookie',
-            cookieDomain: 'localhost',
-            cookieSameSite: 'lax',
-            cookieSecure: false,
-          }),
+          buildEmailPasswordRecipe({ employeeService }),
+          buildSessionRecipe({ config: configService }),
           UserRoles.init(),
         ],
       }),

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { EmployeeModule } from 'src/employee/employee.module';
+import { EmployeeService } from 'src/employee/employee.service';
 import { SuperTokensModule } from 'supertokens-nestjs';
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import Session from 'supertokens-node/recipe/session';
@@ -7,10 +9,39 @@ import UserRoles from 'supertokens-node/recipe/userroles';
 @Module({
   imports: [
     SuperTokensModule.forRootAsync({
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
+      imports: [EmployeeModule],
+      inject: [ConfigService, EmployeeService],
+      useFactory: (
+        configService: ConfigService,
+        employeeService: EmployeeService,
+      ) => ({
         ...configService.get('supertokens'),
-        recipeList: [EmailPassword.init(), Session.init(), UserRoles.init()],
+        recipeList: [
+          EmailPassword.init({
+            override: {
+              functions: (orig) => ({
+                ...orig,
+                signUp: async (input) => {
+                  const res = await orig.signUp(input);
+                  if (res.status === 'OK') {
+                    await employeeService.createEmployee({
+                      email: res.user.emails[0],
+                    });
+                  }
+                  // TODO!:delete user if could not create employee
+                  return res;
+                },
+              }),
+            },
+          }),
+          Session.init({
+            getTokenTransferMethod: () => 'cookie',
+            cookieDomain: 'localhost',
+            cookieSameSite: 'lax',
+            cookieSecure: false,
+          }),
+          UserRoles.init(),
+        ],
       }),
     }),
   ],

--- a/src/auth/claims/app-user-id.claim.ts
+++ b/src/auth/claims/app-user-id.claim.ts
@@ -1,0 +1,15 @@
+import { PrimitiveClaim } from 'supertokens-node/recipe/session/claims';
+import UserMetadata from 'supertokens-node/recipe/usermetadata';
+import { APP_USER_ID_METADATA_KEY } from '../constants/app-user-id-key';
+
+export const AppUserIdClaim = new PrimitiveClaim<string>({
+  key: APP_USER_ID_METADATA_KEY,
+  async fetchValue(userId) {
+    const result = await UserMetadata.getUserMetadata(userId);
+    const value = result.metadata?.[APP_USER_ID_METADATA_KEY];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+    return undefined;
+  },
+});

--- a/src/auth/constants/app-user-id-key.ts
+++ b/src/auth/constants/app-user-id-key.ts
@@ -1,0 +1,1 @@
+export const APP_USER_ID_METADATA_KEY = 'appUserId';

--- a/src/auth/constants/roles.ts
+++ b/src/auth/constants/roles.ts
@@ -11,15 +11,21 @@ enum RESOURCE {
   SELF = 'self',
 }
 
+export enum ROLE_NAMES {
+  USER = 'user',
+  ADMIN = 'admin',
+  SELLER = 'seller',
+}
+
 // format: ACTION:RESOURCE
 export const ROLES: Record<string, string[]> = {
-  user: [
+  [ROLE_NAMES.USER]: [
     `${ACTION.READ}:${RESOURCE.SELF}`,
     `${ACTION.UPDATE}:${RESOURCE.SELF}`,
   ],
-  admin: [
+  [ROLE_NAMES.ADMIN]: [
     `${ACTION.CREATE}:${RESOURCE.CLOTHES}`,
     `${ACTION.READ}:${RESOURCE.CLOTHES}`,
   ],
-  seller: [`${ACTION.READ}:${RESOURCE.CLOTHES}`],
+  [ROLE_NAMES.SELLER]: [`${ACTION.READ}:${RESOURCE.CLOTHES}`],
 };

--- a/src/auth/constants/roles.ts
+++ b/src/auth/constants/roles.ts
@@ -1,0 +1,25 @@
+enum ACTION {
+  CREATE = 'create',
+  READ = 'read',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}
+
+enum RESOURCE {
+  CLOTHES = 'clothes',
+  EMPLOYEES = 'employees',
+  SELF = 'self',
+}
+
+// format: ACTION:RESOURCE
+export const ROLE_DEFS: Record<string, string[]> = {
+  user: [
+    `${ACTION.READ}:${RESOURCE.SELF}`,
+    `${ACTION.UPDATE}:${RESOURCE.SELF}`,
+  ],
+  admin: [
+    `${ACTION.CREATE}:${RESOURCE.CLOTHES}`,
+    `${ACTION.READ}:${RESOURCE.CLOTHES}`,
+  ],
+  seller: [`${ACTION.READ}:${RESOURCE.CLOTHES}`],
+};

--- a/src/auth/constants/roles.ts
+++ b/src/auth/constants/roles.ts
@@ -12,7 +12,7 @@ enum RESOURCE {
 }
 
 // format: ACTION:RESOURCE
-export const ROLE_DEFS: Record<string, string[]> = {
+export const ROLES: Record<string, string[]> = {
   user: [
     `${ACTION.READ}:${RESOURCE.SELF}`,
     `${ACTION.UPDATE}:${RESOURCE.SELF}`,

--- a/src/auth/recipes/email-password.recipe.ts
+++ b/src/auth/recipes/email-password.recipe.ts
@@ -4,6 +4,7 @@ import SuperTokens from 'supertokens-node';
 import { BadRequestException } from '@nestjs/common';
 import UserMetadata from 'supertokens-node/recipe/usermetadata';
 import { APP_USER_ID_METADATA_KEY } from '../constants/app-user-id-key';
+import { EmployeeEntity } from 'src/employee/entities/employee.entitiy';
 
 export function buildEmailPasswordRecipe(dependencies: {
   employeeService: EmployeeService;
@@ -15,27 +16,36 @@ export function buildEmailPasswordRecipe(dependencies: {
       functions: (orig) => ({
         ...orig,
         async signUp(input) {
-          const [res, appUser] = await Promise.all([
-            orig.signUp(input),
-            employeeService.createEmployee({
-              email: input.email,
-            }),
-          ]);
+          const res = await orig.signUp(input);
+          if (res.status !== 'OK') {
+            return res;
+          }
 
-          if (!appUser && res.status === 'OK') {
+          let appUser: EmployeeEntity | null = null;
+          try {
+            appUser = await employeeService.createEmployee({
+              email: input.email,
+            });
+          } catch (error) {
             SuperTokens.deleteUser(res.user.id);
+            throw error;
+          }
+
+          if (!appUser) {
+            await SuperTokens.deleteUser(res.user.id);
             throw new BadRequestException('Could not create user');
           }
 
-          if (appUser && res.status !== 'OK') {
-            await employeeService.deleteEmployee(appUser.id);
-          }
-
-          if (res.status === 'OK' && appUser) {
+          try {
             await UserMetadata.updateUserMetadata(res.user.id, {
               [APP_USER_ID_METADATA_KEY]: appUser.id,
             });
+          } catch (error) {
+            await employeeService.deleteEmployee(appUser.id);
+            await SuperTokens.deleteUser(res.user.id);
+            throw error;
           }
+
           return res;
         },
       }),

--- a/src/auth/recipes/email-password.recipe.ts
+++ b/src/auth/recipes/email-password.recipe.ts
@@ -1,5 +1,7 @@
 import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import { EmployeeService } from 'src/employee/employee.service';
+import SuperTokens from 'supertokens-node';
+import { BadRequestException } from '@nestjs/common';
 
 export function buildEmailPasswordRecipe(dependencies: {
   employeeService: EmployeeService;
@@ -12,12 +14,20 @@ export function buildEmailPasswordRecipe(dependencies: {
         ...orig,
         async signUp(input) {
           const res = await orig.signUp(input);
+          let appUser = null;
           if (res.status === 'OK') {
-            await employeeService.createEmployee({
+            appUser = await employeeService.createEmployee({
               email: res.user.emails[0],
             });
+            if (!appUser) {
+              await SuperTokens.deleteUser(res.user.id);
+              throw new BadRequestException('Could not create user');
+            }
+            await SuperTokens.createUserIdMapping({
+              superTokensUserId: res.user.id,
+              externalUserId: appUser.id,
+            });
           }
-          // TODO: si falla createEmployee, revertir creando un cleanup del user en SuperTokens
           return res;
         },
       }),

--- a/src/auth/recipes/email-password.recipe.ts
+++ b/src/auth/recipes/email-password.recipe.ts
@@ -2,6 +2,7 @@ import EmailPassword from 'supertokens-node/recipe/emailpassword';
 import { EmployeeService } from 'src/employee/employee.service';
 import SuperTokens from 'supertokens-node';
 import { BadRequestException } from '@nestjs/common';
+import UserMetadata from 'supertokens-node/recipe/usermetadata';
 
 export function buildEmailPasswordRecipe(dependencies: {
   employeeService: EmployeeService;
@@ -13,19 +14,25 @@ export function buildEmailPasswordRecipe(dependencies: {
       functions: (orig) => ({
         ...orig,
         async signUp(input) {
-          const res = await orig.signUp(input);
-          let appUser = null;
-          if (res.status === 'OK') {
-            appUser = await employeeService.createEmployee({
-              email: res.user.emails[0],
-            });
-            if (!appUser) {
-              await SuperTokens.deleteUser(res.user.id);
-              throw new BadRequestException('Could not create user');
-            }
-            await SuperTokens.createUserIdMapping({
-              superTokensUserId: res.user.id,
-              externalUserId: appUser.id,
+          const [res, appUser] = await Promise.all([
+            orig.signUp(input),
+            employeeService.createEmployee({
+              email: input.email,
+            }),
+          ]);
+
+          if (!appUser && res.status === 'OK') {
+            SuperTokens.deleteUser(res.user.id);
+            throw new BadRequestException('Could not create user');
+          }
+
+          if (appUser && res.status !== 'OK') {
+            await employeeService.deleteEmployee(appUser.id);
+          }
+
+          if (res.status === 'OK' && appUser) {
+            await UserMetadata.updateUserMetadata(res.user.id, {
+              appUserId: appUser.id,
             });
           }
           return res;

--- a/src/auth/recipes/email-password.recipe.ts
+++ b/src/auth/recipes/email-password.recipe.ts
@@ -3,6 +3,7 @@ import { EmployeeService } from 'src/employee/employee.service';
 import SuperTokens from 'supertokens-node';
 import { BadRequestException } from '@nestjs/common';
 import UserMetadata from 'supertokens-node/recipe/usermetadata';
+import { APP_USER_ID_METADATA_KEY } from '../constants/app-user-id-key';
 
 export function buildEmailPasswordRecipe(dependencies: {
   employeeService: EmployeeService;
@@ -32,7 +33,7 @@ export function buildEmailPasswordRecipe(dependencies: {
 
           if (res.status === 'OK' && appUser) {
             await UserMetadata.updateUserMetadata(res.user.id, {
-              appUserId: appUser.id,
+              [APP_USER_ID_METADATA_KEY]: appUser.id,
             });
           }
           return res;

--- a/src/auth/recipes/email-password.recipe.ts
+++ b/src/auth/recipes/email-password.recipe.ts
@@ -1,0 +1,26 @@
+import EmailPassword from 'supertokens-node/recipe/emailpassword';
+import { EmployeeService } from 'src/employee/employee.service';
+
+export function buildEmailPasswordRecipe(dependencies: {
+  employeeService: EmployeeService;
+}) {
+  const { employeeService } = dependencies;
+
+  return EmailPassword.init({
+    override: {
+      functions: (orig) => ({
+        ...orig,
+        async signUp(input) {
+          const res = await orig.signUp(input);
+          if (res.status === 'OK') {
+            await employeeService.createEmployee({
+              email: res.user.emails[0],
+            });
+          }
+          // TODO: si falla createEmployee, revertir creando un cleanup del user en SuperTokens
+          return res;
+        },
+      }),
+    },
+  });
+}

--- a/src/auth/recipes/session.recipe.ts
+++ b/src/auth/recipes/session.recipe.ts
@@ -1,8 +1,9 @@
 import Session from 'supertokens-node/recipe/session';
 import { ConfigService } from '@nestjs/config';
+import { AppUserIdClaim } from '../claims/app-user-id.claim';
 
-export function buildSessionRecipe(deps: { config: ConfigService }) {
-  const { config } = deps;
+export function buildSessionRecipe(dependencies: { config: ConfigService }) {
+  const { config } = dependencies;
 
   const cookieDomain = config.get<string>('auth.cookieDomain') ?? 'localhost';
   const cookieSameSite =
@@ -15,5 +16,15 @@ export function buildSessionRecipe(deps: { config: ConfigService }) {
     cookieDomain,
     cookieSameSite,
     cookieSecure,
+    override: {
+      functions: (original) => ({
+        ...original,
+        async createNewSession(input) {
+          const session = await original.createNewSession(input);
+          await session.fetchAndSetClaim(AppUserIdClaim, input.userContext);
+          return session;
+        },
+      }),
+    },
   });
 }

--- a/src/auth/recipes/session.recipe.ts
+++ b/src/auth/recipes/session.recipe.ts
@@ -5,12 +5,13 @@ import { AppUserIdClaim } from '../claims/app-user-id.claim';
 export function buildSessionRecipe(dependencies: { config: ConfigService }) {
   const { config } = dependencies;
 
-  const cookieDomain = config.get<string>('auth.cookieDomain') ?? 'localhost';
+  const cookieDomain = config.get<string>('cookie.cookieDomain');
   const cookieSameSite =
-    (config.get<string>('auth.cookieSameSite') as 'lax' | 'strict' | 'none') ??
-    'lax';
-  const cookieSecure = config.get<boolean>('auth.cookieSecure') ?? false;
-
+    (config.get<string>('cookie.cookieSameSite') as
+      | 'lax'
+      | 'strict'
+      | 'none') ?? 'lax';
+  const cookieSecure = config.get<boolean>('cookie.cookieSecure') ?? false;
   return Session.init({
     getTokenTransferMethod: () => 'cookie',
     cookieDomain,

--- a/src/auth/recipes/session.recipe.ts
+++ b/src/auth/recipes/session.recipe.ts
@@ -4,7 +4,6 @@ import { ConfigService } from '@nestjs/config';
 export function buildSessionRecipe(deps: { config: ConfigService }) {
   const { config } = deps;
 
-  // opcional: leer desde env/config
   const cookieDomain = config.get<string>('auth.cookieDomain') ?? 'localhost';
   const cookieSameSite =
     (config.get<string>('auth.cookieSameSite') as 'lax' | 'strict' | 'none') ??

--- a/src/auth/recipes/session.recipe.ts
+++ b/src/auth/recipes/session.recipe.ts
@@ -1,0 +1,20 @@
+import Session from 'supertokens-node/recipe/session';
+import { ConfigService } from '@nestjs/config';
+
+export function buildSessionRecipe(deps: { config: ConfigService }) {
+  const { config } = deps;
+
+  // opcional: leer desde env/config
+  const cookieDomain = config.get<string>('auth.cookieDomain') ?? 'localhost';
+  const cookieSameSite =
+    (config.get<string>('auth.cookieSameSite') as 'lax' | 'strict' | 'none') ??
+    'lax';
+  const cookieSecure = config.get<boolean>('auth.cookieSecure') ?? false;
+
+  return Session.init({
+    getTokenTransferMethod: () => 'cookie',
+    cookieDomain,
+    cookieSameSite,
+    cookieSecure,
+  });
+}

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -6,7 +6,11 @@ import * as config from './env';
     NestConfigModule.forRoot({
       envFilePath: ['.env.local', '.env'],
       isGlobal: true,
-      load: [config.supertokensConfig, config.typeormConfig],
+      load: [
+        config.supertokensConfig,
+        config.typeormConfig,
+        config.cookieConfig,
+      ],
     }),
   ],
 })

--- a/src/config/env/cookie.config.ts
+++ b/src/config/env/cookie.config.ts
@@ -1,0 +1,11 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('cookie', () => {
+  const { COOKIE_DOMAIN, COOKIE_SAME_SITE, COOKIE_SECURE } = process.env;
+
+  return {
+    cookieDomain: COOKIE_DOMAIN,
+    cookieSameSite: COOKIE_SAME_SITE,
+    cookieSecure: COOKIE_SECURE === 'true',
+  };
+});

--- a/src/config/env/index.ts
+++ b/src/config/env/index.ts
@@ -1,2 +1,3 @@
 export { default as supertokensConfig } from './supertokens.config';
 export { default as typeormConfig } from './typeorm.config';
+export { default as cookieConfig } from './cookie.config';

--- a/src/config/env/typeorm.config.ts
+++ b/src/config/env/typeorm.config.ts
@@ -1,5 +1,6 @@
 import { registerAs } from '@nestjs/config';
 import { CustomerEntity } from 'src/customer/entities/customer.entity';
+import { EmployeeEntity } from 'src/employee/entities/employee.entitiy';
 
 export default registerAs('typeorm', () => {
   const { DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_NAME } = process.env;
@@ -30,7 +31,7 @@ export default registerAs('typeorm', () => {
     username: DB_USERNAME,
     password: DB_PASSWORD,
     database: DB_NAME,
-    entities: [CustomerEntity],
+    entities: [CustomerEntity, EmployeeEntity],
     synchronize: process.env.NODE_ENV !== 'production',
   };
 });

--- a/src/employee/dtos/create-employee.dto.ts
+++ b/src/employee/dtos/create-employee.dto.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateEmployeeDTO {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  names: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  lastNames: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  reference: string;
+}

--- a/src/employee/dtos/create-employee.dto.ts
+++ b/src/employee/dtos/create-employee.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateEmployeeDTO {
+  @IsString()
+  @IsEmail()
+  @IsNotEmpty()
+  @MaxLength(50)
+  email: string;
+}

--- a/src/employee/dtos/update-employee.dto.ts
+++ b/src/employee/dtos/update-employee.dto.ts
@@ -1,13 +1,13 @@
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class UpdateEmployeeDTO {
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
   @MaxLength(100)
-  names: string;
+  names?: string;
 
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
   @MaxLength(100)
-  lastNames: string;
+  lastNames?: string;
 }

--- a/src/employee/dtos/update-employee.dto.ts
+++ b/src/employee/dtos/update-employee.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class UpdateEmployeeDTO {
   @IsString()
@@ -13,6 +13,7 @@ export class UpdateEmployeeDTO {
 
   @IsString()
   @IsNotEmpty()
+  @IsEmail()
   @MaxLength(50)
   email: string;
 }

--- a/src/employee/dtos/update-employee.dto.ts
+++ b/src/employee/dtos/update-employee.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class UpdateEmployeeDTO {
   @IsString()
@@ -10,10 +10,4 @@ export class UpdateEmployeeDTO {
   @IsNotEmpty()
   @MaxLength(100)
   lastNames: string;
-
-  @IsString()
-  @IsNotEmpty()
-  @IsEmail()
-  @MaxLength(50)
-  email: string;
 }

--- a/src/employee/dtos/update-employee.dto.ts
+++ b/src/employee/dtos/update-employee.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-export class CreateEmployeeDTO {
+export class UpdateEmployeeDTO {
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
@@ -14,5 +14,5 @@ export class CreateEmployeeDTO {
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)
-  reference: string;
+  email: string;
 }

--- a/src/employee/employee.controller.ts
+++ b/src/employee/employee.controller.ts
@@ -1,17 +1,29 @@
-import { Body, Controller, Param, Patch } from '@nestjs/common';
+import { Body, Controller, Patch, UseGuards } from '@nestjs/common';
 import { EmployeeService } from './employee.service';
 import { UpdateEmployeeDTO } from './dtos/update-employee.dto';
+import {
+  Session,
+  SuperTokensAuthGuard,
+  VerifySession,
+} from 'supertokens-nestjs';
+import { SessionContainer } from 'supertokens-node/recipe/session';
 import { EmployeeEntity } from './entities/employee.entitiy';
-
+@UseGuards(SuperTokensAuthGuard)
 @Controller('employee')
 export class EmployeeController {
   constructor(private readonly employeeService: EmployeeService) {}
 
-  @Patch(':id')
+  @Patch()
+  @VerifySession()
   async updateEmployee(
-    @Param('id') id: string,
     @Body() updateEmployeeDTO: UpdateEmployeeDTO,
+    @Session() session: SessionContainer,
   ): Promise<EmployeeEntity> {
-    return await this.employeeService.updateEmployee(id, updateEmployeeDTO);
+    const appUserId = session.getAccessTokenPayload().appUserId;
+    console.log('appUserId', appUserId);
+    return await this.employeeService.updateEmployee(
+      appUserId.v,
+      updateEmployeeDTO,
+    );
   }
 }

--- a/src/employee/employee.controller.ts
+++ b/src/employee/employee.controller.ts
@@ -1,4 +1,10 @@
-import { Body, Controller, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Patch,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
 import { EmployeeService } from './employee.service';
 import { UpdateEmployeeDTO } from './dtos/update-employee.dto';
 import {
@@ -20,7 +26,9 @@ export class EmployeeController {
     @Session() session: SessionContainer,
   ): Promise<EmployeeEntity> {
     const appUserId = session.getAccessTokenPayload().appUserId;
-    console.log('appUserId', appUserId);
+    if (!appUserId) {
+      throw new UnauthorizedException('Session missing app user id');
+    }
     return await this.employeeService.updateEmployee(
       appUserId.v,
       updateEmployeeDTO,

--- a/src/employee/employee.controller.ts
+++ b/src/employee/employee.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Param, Patch } from '@nestjs/common';
+import { EmployeeService } from './employee.service';
+import { UpdateEmployeeDTO } from './dtos/update-employee.dto';
+import { EmployeeEntity } from './entities/employee.entitiy';
+
+@Controller('employee')
+export class EmployeeController {
+  constructor(private readonly employeeService: EmployeeService) {}
+
+  @Patch(':id')
+  async updateEmployee(
+    @Param('id') id: string,
+    @Body() updateEmployeeDTO: UpdateEmployeeDTO,
+  ): Promise<EmployeeEntity> {
+    return await this.employeeService.updateEmployee(id, updateEmployeeDTO);
+  }
+}

--- a/src/employee/employee.module.ts
+++ b/src/employee/employee.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EmployeeEntity } from './entities/employee.entitiy';
+import { EmployeeService } from './employee.service';
+import { EmployeeController } from './employee.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([EmployeeEntity])],
+  providers: [EmployeeService],
+  controllers: [EmployeeController],
+  exports: [EmployeeService],
 })
 export class EmployeeModule {}

--- a/src/employee/employee.module.ts
+++ b/src/employee/employee.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EmployeeEntity } from './entities/employee.entitiy';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EmployeeEntity])],
+})
+export class EmployeeModule {}

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -24,7 +24,9 @@ export class EmployeeService {
       });
       return await this.employeeRepository.save(employee);
     } catch (error) {
-      console.log(error);
+      if (error.code === '23505') {
+        throw new BadRequestException('Employee email already exists');
+      }
       throw new BadRequestException('Could not create employee');
     }
   }

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -4,14 +4,15 @@ import { EmployeeEntity } from './entities/employee.entitiy';
 import { Repository } from 'typeorm/repository/Repository';
 import { CreateEmployeeDTO } from './dtos/create-employee.dto';
 import { UpdateEmployeeDTO } from './dtos/update-employee.dto';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class EmployeeService {
+  private readonly logger = new Logger(EmployeeService.name);
   constructor(
     @InjectRepository(EmployeeEntity)
     private readonly employeeRepository: Repository<EmployeeEntity>,
   ) {}
-
   async createEmployee(
     createEmployeDTO: CreateEmployeeDTO,
   ): Promise<EmployeeEntity> {
@@ -37,6 +38,14 @@ export class EmployeeService {
       return await this.employeeRepository.findOneBy({ id });
     } catch (error) {
       throw new BadRequestException('Could not update employee');
+    }
+  }
+
+  async deleteEmployee(id: string): Promise<void> {
+    try {
+      await this.employeeRepository.delete(id);
+    } catch (error) {
+      this.logger.error('Error deleting employee or does not exist');
     }
   }
 }

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -51,10 +51,15 @@ export class EmployeeService {
 
   async deleteEmployee(id: string): Promise<void> {
     try {
-      await this.employeeRepository.delete(id);
+      const result = await this.employeeRepository.delete(id);
+      if (result.affected === 0) {
+        throw new BadRequestException('Employee not found');
+      }
     } catch (error) {
       this.logger.error('Error deleting employee or does not exist');
-      throw new BadRequestException('Could not delete employee');
+      throw new BadRequestException(
+        'Error deleting employee or does not exist',
+      );
     }
   }
 }

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -35,12 +35,18 @@ export class EmployeeService {
     id: string,
     updateEmployeeDTO: UpdateEmployeeDTO,
   ): Promise<EmployeeEntity> {
-    try {
-      await this.employeeRepository.update(id, updateEmployeeDTO);
-      return await this.employeeRepository.findOneBy({ id });
-    } catch (error) {
-      throw new BadRequestException('Could not update employee');
+    if (!id)
+      throw new BadRequestException(
+        'Employee id is required. Verify your session',
+      );
+    const response = await this.employeeRepository.update(
+      id,
+      updateEmployeeDTO,
+    );
+    if (response.affected === 0) {
+      throw new BadRequestException('Employee not found');
     }
+    return await this.employeeRepository.findOneBy({ id });
   }
 
   async deleteEmployee(id: string): Promise<void> {

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -1,0 +1,42 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EmployeeEntity } from './entities/employee.entitiy';
+import { Repository } from 'typeorm/repository/Repository';
+import { CreateEmployeeDTO } from './dtos/create-employee.dto';
+import { UpdateEmployeeDTO } from './dtos/update-employee.dto';
+
+@Injectable()
+export class EmployeeService {
+  constructor(
+    @InjectRepository(EmployeeEntity)
+    private readonly employeeRepository: Repository<EmployeeEntity>,
+  ) {}
+
+  async createEmployee(
+    createEmployeDTO: CreateEmployeeDTO,
+  ): Promise<EmployeeEntity> {
+    try {
+      const employee: EmployeeEntity = this.employeeRepository.create({
+        ...createEmployeDTO,
+        names: '',
+        lastNames: '',
+      });
+      return await this.employeeRepository.save(employee);
+    } catch (error) {
+      console.log(error);
+      throw new BadRequestException('Could not create employee');
+    }
+  }
+
+  async updateEmployee(
+    id: string,
+    updateEmployeeDTO: UpdateEmployeeDTO,
+  ): Promise<EmployeeEntity> {
+    try {
+      await this.employeeRepository.update(id, updateEmployeeDTO);
+      return await this.employeeRepository.findOneBy({ id });
+    } catch (error) {
+      throw new BadRequestException('Could not update employee');
+    }
+  }
+}

--- a/src/employee/employee.service.ts
+++ b/src/employee/employee.service.ts
@@ -54,6 +54,7 @@ export class EmployeeService {
       await this.employeeRepository.delete(id);
     } catch (error) {
       this.logger.error('Error deleting employee or does not exist');
+      throw new BadRequestException('Could not delete employee');
     }
   }
 }

--- a/src/employee/entities/employee.entitiy.ts
+++ b/src/employee/entities/employee.entitiy.ts
@@ -6,7 +6,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-@Entity('customer')
+@Entity('employee')
 export class EmployeeEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/employee/entities/employee.entitiy.ts
+++ b/src/employee/entities/employee.entitiy.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('customer')
+export class EmployeeEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  names: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: false })
+  lastNames: string;
+
+  @Column({ type: 'varchar', length: 50, nullable: false, unique: true })
+  email: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { SuperTokensExceptionFilter } from 'supertokens-nestjs';
+import supertokens from 'supertokens-node';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const configService = app.get(ConfigService);
+  app.enableCors({
+    origin: configService.get('supertokens').appInfo.websiteDomain,
+    allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
+    credentials: true,
+  });
+  app.useGlobalFilters(new SuperTokensExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,


### PR DESCRIPTION
This PR wires up authentication/authorization with SuperTokens and introduces the **Employee** slice to support user records in our DB.

## What’s included

* **SuperTokens integration (NestJS)**

  * Recipes: EmailPassword, Session (cookies), UserRoles.
  * CORS enabled with dynamic origin and SuperTokens headers.
  * Global `SuperTokensExceptionFilter` and `ValidationPipe` (transform + whitelist + forbidNonWhitelisted).
* **RBAC**

  * Roles: `user`, `admin`, `seller`.
  * Permission strings (ACTION:RESOURCE) for clothes, employees, and self.
  * Seeder to create roles/permissions and two default users (admin/seller).
* **Session claims**

  * `AppUserIdClaim` backed by UserMetadata.
  * Session recipe override to fetch & set the claim at session creation.
* **Email/Password signup flow**

  * Override: on sign-up, create `Employee` in DB.
  * Two-way consistency: rollback ST user if DB create fails; rollback DB if ST fails.
  * Persist `appUserId` in UserMetadata for later use in business logic.
* **Employee domain**

  * TypeORM entity (`employee`), repository wiring, service, controller.
  * DTOs: `CreateEmployeeDTO` (email) and `UpdateEmployeeDTO` (names/lastNames).
  * Protected PATCH `/employee` using `SuperTokensAuthGuard` + `@VerifySession()`, reading `appUserId` from the session.
* **Config & tooling**

  * TypeORM config now includes `EmployeeEntity`.
  * `.env.example` gains seed credentials for the default users.
  * `package.json` adds `seed` script (`ts-node ./scripts/rbac.seeder.ts`).

## Why

We need a consistent auth backbone with role-based permissions and a minimal user record in our own DB to drive domain logic (e.g., linking sessions/claims to app users). This PR delivers that baseline.

## How to test locally

1. **Environment**

   * Ensure SuperTokens Core is running.
   * Set required vars (examples):

     ```
     CONNECTION_URI=...
     APP_NAME=...
     API_DOMAIN=http://localhost:3000
     WEBSITE_DOMAIN=http://localhost:3001

     DB_HOST=...
     DB_PORT=5432
     DB_USERNAME=...
     DB_PASSWORD=...
     DB_NAME=...

     EMAIL_ADMIN=admin@example.com
     EMAIL_EMPLOYEE=seller@example.com
     ADMIN_PASSWORD=ChangeMe1!
     EMPLOYEE_PASSWORD=ChangeMe1!
     ```
2. **Install & run**

   ```bash
   pnpm i
   pnpm start:dev
   ```
3. **Seed roles & users**

   ```bash
   pnpm seed
   ```

   * Expected: roles created; admin and seller users created in SuperTokens + corresponding `employee` rows.
4. **Sign in (from the website domain)**

   * Create a session via EmailPassword sign-in.
   * Verify cookies are set and CORS is allowed.
5. **Update employee profile**

   * Call `PATCH /employee` with a valid session:

     ```json
     { "names": "Jane", "lastNames": "Doe" }
     ```
   * Expected: 200 with updated entity; server logs show `appUserId` read from the session.

## Notes for reviewers

* Lockfile churn is from adding SuperTokens recipes, TypeORM entity wiring, and `dotenv`.
* DB schema is managed via TypeORM with `synchronize` (non-prod only).
* Seeder exits on existing accounts to prevent duplicate runs.

## Follow-ups (out of scope here)

* Route guards/matchers per permission string for finer-grained RBAC on API routes.
* Admin UX to assign roles and manage users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employee module with entity, DTOs, service and a protected PATCH /employee endpoint for profile updates.
  * Signup flow now creates a linked employee profile and stores an app-user identifier in sessions/metadata.

* **Improvements**
  * Sessions/cookies enhanced for secure defaults and app-user propagation; CORS updated to include auth-required headers.
  * Global auth exception handling registered.

* **Chores**
  * Seed script for roles/permissions and sample users added; dotenv and new env vars introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->