### PR TITLE
Setup guide for AWS RDS databases and schemas

### DIFF
--- a/docs/setup-rds.md
+++ b/docs/setup-rds.md
@@ -1,0 +1,47 @@
+# Setting Up Databases in AWS RDS for the Application and SuperTokens
+
+This guide assumes that you already have an AWS RDS PostgreSQL instance running and that you are connected to the instance using the administrative database (usually `postgres`). The setup will use a single database with two separate schemas: one for the application and one for SuperTokens.
+
+Follow these steps to configure the schemas:
+
+1. **Create Development Database**
+
+   ```sql
+   CREATE DATABASE dumi_development;
+   ```
+
+2. **Connect to Database**
+
+   ```
+   \c dumi_development
+   ```
+
+   If your are using Dbeaver or a similar client just create a new connection a change database name to **dumi_development**
+
+3. **Create Schemas**
+
+   ```sql
+    CREATE SCHEMA supertokens;
+    CREATE SCHEMA dumi_app;
+   ```
+
+4. **Create Users**
+
+   ```sql
+    CREATE USER supertokens_user WITH PASSWORD 'secure_password';
+    CREATE USER dumi_app_user WITH PASSWORD 'secure_password';
+   ```
+
+5. **Grant Privileges**
+
+   ```sql
+   GRANT ALL PRIVILEGES ON SCHEMA supertokens TO supertokens_user;
+   GRANT ALL PRIVILEGES ON SCHEMA dumi_app TO dumi_app_user;
+   ```
+
+6. **Set SearchPath**
+
+   ```sql
+    ALTER ROLE supertokens_user SET search_path = supertokens;
+    ALTER ROLE dumi_app_user SET search_path = dumi_app;
+   ```


### PR DESCRIPTION
This pull request introduces a new documentation file, `docs/setup-rds.md`, which provides a step-by-step guide for setting up **AWS RDS PostgreSQL** databases for the application.

### Key Changes & Intention

The main goal of this guide is to promote **database separation and security** by:

* **Defining a single database** (`dumi_development`) with **two distinct schemas**: `supertokens` and `dumi_app`.
* **Creating a separate user** for each schema (`supertokens_user` and `dumi_app_user`) with restricted privileges.
* **Separating the SuperTokens core data** (authentication/auth-related tables) from the **general application data**, ensuring that each component only has access to its necessary schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step guide for setting up AWS RDS PostgreSQL using a single database with two schemas (superTokens and dumi_app).
  * Includes instructions to create the development database, connect, create schemas, create users, grant privileges, and configure each user’s search_path.
  * Provides ready-to-use SQL snippets to streamline setup and ensure proper isolation between session management and application data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->