### PR TITLE
feat: add api prefix to nest app and supertokens core

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# API Configuration
+
+API_PREFIX=your_api_prefix
+
 # SuperTokens Configuration
 
 CONNECTION_URI=your_supertokens_connection_uri
@@ -14,6 +18,7 @@ DB_USERNAME=your_database_username
 DB_PASSWORD=your_database_password
 DB_NAME=your_database_name
 DB_SSL=true_or_false
+
 # Seed Users Credentials
 EMAIL_ADMIN=your_admin_email
 EMAIL_EMPLOYEE=your_employee_email

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -10,6 +10,7 @@ import * as config from './env';
         config.supertokensConfig,
         config.typeormConfig,
         config.cookieConfig,
+        config.apiConfig,
       ],
     }),
   ],

--- a/src/config/env/api.config.ts
+++ b/src/config/env/api.config.ts
@@ -1,0 +1,9 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('api', () => {
+  const { API_PREFIX } = process.env;
+
+  return {
+    prefix: API_PREFIX || 'api/v1',
+  };
+});

--- a/src/config/env/index.ts
+++ b/src/config/env/index.ts
@@ -1,3 +1,4 @@
 export { default as supertokensConfig } from './supertokens.config';
 export { default as typeormConfig } from './typeorm.config';
 export { default as cookieConfig } from './cookie.config';
+export { default as apiConfig } from './api.config';

--- a/src/config/env/supertokens.config.ts
+++ b/src/config/env/supertokens.config.ts
@@ -2,14 +2,21 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('supertokens', () => {
   // api key will be used later
-  const { CONNECTION_URI, APP_NAME, API_DOMAIN, WEBSITE_DOMAIN, API_KEY } =
-    process.env;
+  const {
+    CONNECTION_URI,
+    APP_NAME,
+    API_DOMAIN,
+    WEBSITE_DOMAIN,
+    API_KEY,
+    API_PREFIX,
+  } = process.env;
   const missingVars = [
     ['CONNECTION_URI', CONNECTION_URI],
     ['APP_NAME', APP_NAME],
     ['API_DOMAIN', API_DOMAIN],
     ['WEBSITE_DOMAIN', WEBSITE_DOMAIN],
     ['API_KEY', API_KEY],
+    ['API_PREFIX', API_PREFIX],
   ]
     .filter(([, value]) => !value)
     .map(([name]) => name);
@@ -30,6 +37,8 @@ export default registerAs('supertokens', () => {
       appName: APP_NAME,
       apiDomain: API_DOMAIN,
       websiteDomain: WEBSITE_DOMAIN,
+      apiBasePath: `${API_PREFIX}/auth`,
+      websiteBasePath: '/auth',
     },
   };
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@nestjs/config';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
+  app.setGlobalPrefix(configService.get('api').prefix);
   app.enableCors({
     origin: configService.get('supertokens').appInfo.websiteDomain,
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],


### PR DESCRIPTION
This PR add an api prefix from environment variable, and configures supertokens core to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added configurable API prefix (defaults to /api/v1); all endpoints now served under this prefix.
  * Standardized authentication routes under {API_PREFIX}/auth; website auth path remains /auth.
* Documentation
  * Expanded .env.example with API settings, cookie options, and seed credentials for easier setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->