### PR TITLE
Quotes: update flow, richer reads, and minor Customer fixes

### DIFF
--- a/src/customer/customer.controller.ts
+++ b/src/customer/customer.controller.ts
@@ -9,7 +9,7 @@ import { CustomerEntity } from './entities/customer.entity';
 
 @Roles(ROLES.SELLER)
 @UseGuards(SuperTokensAuthGuard, RolesGuard)
-@Controller('customer')
+@Controller('customers')
 export class CustomerController {
   constructor(private readonly customerService: CustomerService) {}
   @Post()

--- a/src/customer/dtos/customer.dto.ts
+++ b/src/customer/dtos/customer.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsString, MaxLength, Length } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsString,
+  MaxLength,
+  Length,
+  IsOptional,
+} from 'class-validator';
 
 export class CreateCustomerDTO {
   @IsString()
@@ -11,8 +17,8 @@ export class CreateCustomerDTO {
   @MaxLength(100)
   lastNames: string;
 
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
   @MaxLength(100)
   reference: string;
 

--- a/src/customer/entities/customer.entity.ts
+++ b/src/customer/entities/customer.entity.ts
@@ -19,7 +19,7 @@ export class CustomerEntity {
   @Column({ type: 'varchar', length: 100, nullable: false })
   lastNames: string;
 
-  @Column({ type: 'varchar', length: 100, nullable: false })
+  @Column({ type: 'varchar', length: 100, nullable: true })
   reference: string;
 
   @Column({ type: 'varchar', length: 20, nullable: false })

--- a/src/quote/dtos/update-quote.dto.ts
+++ b/src/quote/dtos/update-quote.dto.ts
@@ -1,0 +1,39 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  IsUUID,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class UpdateQuoteDTO {
+  @IsNotEmpty()
+  @IsUUID()
+  id: string;
+
+  @IsNotEmpty()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => QuoteDetailDTO)
+  details: QuoteDetailDTO[];
+}
+
+export class QuoteDetailDTO {
+  @IsNotEmpty()
+  @IsString()
+  @IsUUID()
+  clothesVariantId: string;
+
+  @IsNotEmpty()
+  @IsNumber(
+    { allowNaN: false, allowInfinity: false },
+    { message: 'quantity must be a number' },
+  )
+  @IsInt({ message: 'quantity must be an integer' })
+  @Min(1, { message: 'quantity must be at least 1' })
+  quantity: number;
+}

--- a/src/quote/interfaces/clothes-data.interface.ts
+++ b/src/quote/interfaces/clothes-data.interface.ts
@@ -1,0 +1,18 @@
+import { QuoteStatus } from '../enums/status.enum';
+
+export interface QuoteSummary {
+  id: string;
+  total: number;
+  customerId: string;
+  status: QuoteStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  customer: {
+    id: string;
+    names: string;
+    lastNames: string;
+    phone: string;
+  };
+  totalClothes: number;
+  totalUnitsToProduced: number;
+}

--- a/src/quote/interfaces/created-clothes.interface.ts
+++ b/src/quote/interfaces/created-clothes.interface.ts
@@ -1,0 +1,17 @@
+export interface CreatedClothes {
+  total: number;
+  customerId: string;
+  id: string;
+  status: string;
+  createdAt: Date;
+  updatedAt: Date;
+  details: Detail[];
+}
+
+export interface Detail {
+  unitPrice: number;
+  quantity: number;
+  quoteId: string;
+  clothesVariantId: string;
+  id: string;
+}

--- a/src/quote/quote.controller.ts
+++ b/src/quote/quote.controller.ts
@@ -14,6 +14,8 @@ import { SuperTokensAuthGuard } from 'supertokens-nestjs';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { ROLES } from 'src/auth/constants/roles';
+import { QuoteSummary } from './interfaces/clothes-data.interface';
+import { CreatedClothes } from './interfaces/created-clothes.interface';
 
 @Roles(ROLES.SELLER)
 @UseGuards(SuperTokensAuthGuard, RolesGuard)
@@ -22,14 +24,19 @@ export class QuoteController {
   constructor(private readonly quoteService: QuoteService) {}
 
   @Post()
-  async createQuote(@Body() dto: CreateQuoteDTO): Promise<any> {
+  async createQuote(@Body() dto: CreateQuoteDTO): Promise<CreatedClothes> {
     return this.quoteService.createQuote(dto);
+  }
+
+  @Get()
+  async getAllQuotes(): Promise<QuoteSummary[]> {
+    return this.quoteService.getAll();
   }
 
   @Get()
   async getQuotesByStatus(
     @Query('status', new ParseEnumPipe(QuoteStatus)) status: QuoteStatus,
-  ) {
+  ): Promise<QuoteSummary[]> {
     return this.quoteService.getQuotesByStatus(status);
   }
 }

--- a/src/quote/quote.controller.ts
+++ b/src/quote/quote.controller.ts
@@ -2,8 +2,11 @@ import {
   Body,
   Controller,
   Get,
+  Param,
   ParseEnumPipe,
+  ParseUUIDPipe,
   Post,
+  Put,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -16,16 +19,25 @@ import { Roles } from 'src/auth/decorators/roles.decorator';
 import { ROLES } from 'src/auth/constants/roles';
 import { QuoteSummary } from './interfaces/clothes-data.interface';
 import { CreatedClothes } from './interfaces/created-clothes.interface';
+import { UpdateQuoteDTO } from './dtos/update-quote.dto';
+import { QuoteEntity } from './entities/quote.entity';
 
 @Roles(ROLES.SELLER)
 @UseGuards(SuperTokensAuthGuard, RolesGuard)
-@Controller('quote')
+@Controller('quotes')
 export class QuoteController {
   constructor(private readonly quoteService: QuoteService) {}
 
   @Post()
   async createQuote(@Body() dto: CreateQuoteDTO): Promise<CreatedClothes> {
     return this.quoteService.createQuote(dto);
+  }
+
+  @Get(':id')
+  async getQuoteById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<QuoteEntity> {
+    return this.quoteService.getQuoteById(id);
   }
 
   @Get()
@@ -38,5 +50,10 @@ export class QuoteController {
     @Query('status', new ParseEnumPipe(QuoteStatus)) status: QuoteStatus,
   ): Promise<QuoteSummary[]> {
     return this.quoteService.getQuotesByStatus(status);
+  }
+
+  @Put()
+  async updateQuote(@Body() dto: UpdateQuoteDTO): Promise<CreatedClothes> {
+    return this.quoteService.updateQuote(dto);
   }
 }

--- a/src/quote/quote.controller.ts
+++ b/src/quote/quote.controller.ts
@@ -1,9 +1,9 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   Param,
-  ParseEnumPipe,
   ParseUUIDPipe,
   Post,
   Put,
@@ -33,23 +33,27 @@ export class QuoteController {
     return this.quoteService.createQuote(dto);
   }
 
+  @Get()
+  async getQuotes(
+    @Query('status') status?: QuoteStatus,
+  ): Promise<QuoteSummary[]> {
+    if (!status) {
+      return this.quoteService.getAll();
+    }
+    // Validar que sea un valor válido del enum
+    if (!Object.values(QuoteStatus).includes(status)) {
+      throw new BadRequestException(
+        `Invalid status. Valid values: ${Object.values(QuoteStatus).join(', ')}`,
+      );
+    }
+    return this.quoteService.getQuotesByStatus(status);
+  }
+
   @Get(':id')
   async getQuoteById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<QuoteEntity> {
     return this.quoteService.getQuoteById(id);
-  }
-
-  @Get()
-  async getAllQuotes(): Promise<QuoteSummary[]> {
-    return this.quoteService.getAll();
-  }
-
-  @Get()
-  async getQuotesByStatus(
-    @Query('status', new ParseEnumPipe(QuoteStatus)) status: QuoteStatus,
-  ): Promise<QuoteSummary[]> {
-    return this.quoteService.getQuotesByStatus(status);
   }
 
   @Put()

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -13,6 +13,8 @@ import { DataSource } from 'typeorm';
 import { ClothesService } from 'src/clothes/clothes.service';
 import { ClothesPrice } from './interfaces/clothes-price.interface';
 import { QuoteStatus } from './enums/status.enum';
+import { QuoteSummary } from './interfaces/clothes-data.interface';
+import { CreatedClothes } from './interfaces/created-clothes.interface';
 
 @Injectable()
 export class QuoteService {
@@ -26,10 +28,9 @@ export class QuoteService {
     private readonly dataSource: DataSource,
   ) {}
 
-  async createQuote(dto: CreateQuoteDTO): Promise<any> {
+  async createQuote(dto: CreateQuoteDTO): Promise<CreatedClothes> {
     const customer = await this.customerService.getCustomerById(dto.customerId);
     const variantsPrice = await this.getDetailUnitPrice(dto);
-    console.log(variantsPrice);
     const total = this.calculateTotal(variantsPrice);
     const queryRunner = this.dataSource.createQueryRunner();
     try {
@@ -43,7 +44,6 @@ export class QuoteService {
         }),
       );
 
-      console.log(newQuote);
       const detailsToSave = variantsPrice.map((vp) => {
         return this.quoteDetailRepository.create({
           quoteId: newQuote.id,
@@ -52,7 +52,6 @@ export class QuoteService {
           clothesVariantId: vp.variantId,
         });
       });
-      console.log(detailsToSave);
       const savedDetails = await queryRunner.manager.save(
         QuoteDetailEntity,
         detailsToSave,
@@ -60,7 +59,6 @@ export class QuoteService {
       await queryRunner.commitTransaction();
       return { ...newQuote, details: savedDetails };
     } catch (error) {
-      console.log(error);
       await queryRunner.rollbackTransaction();
       throw new BadRequestException('Error creating quote');
     } finally {
@@ -68,21 +66,112 @@ export class QuoteService {
     }
   }
 
-  async getQuotesByStatus(status: QuoteStatus): Promise<QuoteEntity[]> {
-    let quotes: QuoteEntity[] = [];
+  async getAll(): Promise<QuoteSummary[]> {
+    return this.fetchQuotes();
+  }
+
+  async getQuotesByStatus(status: QuoteStatus): Promise<QuoteSummary[]> {
+    return this.fetchQuotes(status);
+  }
+
+  /**
+   * Private method that builds and executes the query to fetch quotes
+   * @param status - Optional. Filter by specific status
+   * @returns Array of quotes with summary
+   */
+  private async fetchQuotes(status?: QuoteStatus): Promise<QuoteSummary[]> {
     try {
-      quotes = await this.quoteRepository.find({
-        where: { status },
-        relations: { customer: true, details: true },
-        order: { createdAt: 'DESC' },
-      });
+      // Build base query
+      const queryBuilder = this.buildQuoteSummaryQuery();
+
+      // Apply status filter if provided
+      if (status) {
+        queryBuilder.where('quote.status = :status', { status });
+      }
+
+      // Execute query
+      const quotes = await queryBuilder.getRawAndEntities();
+
+      // Map results
+      const result = this.mapToQuoteSummary(quotes);
+
+      if (!result || result.length === 0) {
+        const message = status
+          ? `No quotes found for status: ${status}`
+          : 'No quotes found';
+        throw new NotFoundException(message);
+      }
+
+      return result;
     } catch (error) {
-      throw new BadRequestException('Error fetching quotes by status');
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new BadRequestException('Error fetching quotes');
     }
-    if (!quotes || quotes.length === 0) {
-      throw new NotFoundException('No quotes found for the given status');
-    }
-    return quotes;
+  }
+
+  /**
+   * Builds query builder base to get quote summary
+   * @returns Configured QueryBuilder
+   */
+  private buildQuoteSummaryQuery() {
+    return (
+      this.quoteRepository
+        .createQueryBuilder('quote')
+        .leftJoinAndSelect('quote.customer', 'customer')
+        .leftJoin('quote.details', 'detail')
+        .leftJoin('detail.clothesVariant', 'variant')
+        .select([
+          // Quote fields
+          'quote.id',
+          'quote.total',
+          'quote.customerId',
+          'quote.status',
+          'quote.createdAt',
+          'quote.updatedAt',
+          // Customer fields
+          'customer.id',
+          'customer.names',
+          'customer.lastNames',
+          'customer.phone',
+        ])
+        // Total unique base garments involved
+        .addSelect('COUNT(DISTINCT variant.clothes_id)', 'totalClothes')
+        // Total units to produce (sum of quantities)
+        .addSelect('COALESCE(SUM(detail.quantity), 0)', 'totalUnitsToProduced')
+        .groupBy('quote.id')
+        .addGroupBy('customer.id')
+        .orderBy('quote.createdAt', 'DESC')
+    );
+  }
+
+  /**
+   * Maps the results of the query to the QuoteSummary interface
+   * @param quotes - Result of getRawAndEntities()
+   * @returns Array of QuoteSummary
+   */
+  private mapToQuoteSummary(quotes: {
+    entities: QuoteEntity[];
+    raw: any[];
+  }): QuoteSummary[] {
+    return quotes.entities.map((quote, index) => ({
+      id: quote.id,
+      total: quote.total,
+      customerId: quote.customerId,
+      status: quote.status,
+      createdAt: quote.createdAt,
+      updatedAt: quote.updatedAt,
+      customer: {
+        id: quote.customer.id,
+        names: quote.customer.names,
+        lastNames: quote.customer.lastNames,
+        phone: quote.customer.phone,
+      },
+      totalClothes: parseInt(quotes.raw[index].totalClothes) || 0,
+      totalUnitsToProduced:
+        parseInt(quotes.raw[index].totalUnitsToProduced) || 0,
+    }));
   }
 
   private async getDetailUnitPrice(

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -15,6 +15,7 @@ import { ClothesPrice } from './interfaces/clothes-price.interface';
 import { QuoteStatus } from './enums/status.enum';
 import { QuoteSummary } from './interfaces/clothes-data.interface';
 import { CreatedClothes } from './interfaces/created-clothes.interface';
+import { UpdateQuoteDTO } from './dtos/update-quote.dto';
 
 @Injectable()
 export class QuoteService {
@@ -70,8 +71,94 @@ export class QuoteService {
     return this.fetchQuotes();
   }
 
+  async getQuoteById(id: string): Promise<QuoteEntity> {
+    try {
+      const quote = await this.quoteRepository.findOne({
+        where: { id },
+        relations: ['customer', 'details', 'details.clothesVariant'],
+      });
+      if (!quote) {
+        throw new NotFoundException(`Quote with ID ${id} not found`);
+      }
+      return quote;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw new BadRequestException(`Error fetching quote with ID ${id}`);
+    }
+  }
+
   async getQuotesByStatus(status: QuoteStatus): Promise<QuoteSummary[]> {
     return this.fetchQuotes(status);
+  }
+
+  async updateQuote(dto: UpdateQuoteDTO): Promise<CreatedClothes> {
+    // Verificar que la cotización existe
+    const existingQuote = await this.quoteRepository.findOne({
+      where: { id: dto.id },
+      relations: ['customer'],
+    });
+
+    if (!existingQuote) {
+      throw new NotFoundException(`Quote with ID ${dto.id} not found`);
+    }
+
+    // Calcular precios de las nuevas variantes (reutiliza lógica de createQuote)
+    const variantsPrice = await this.getDetailUnitPrice({
+      details: dto.details,
+      customerId: existingQuote.customerId, // Necesario para la validación
+    } as CreateQuoteDTO);
+
+    const newTotal = this.calculateTotal(variantsPrice);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    try {
+      await queryRunner.connect();
+      await queryRunner.startTransaction();
+
+      // 1. Eliminar todos los detalles existentes
+      await queryRunner.manager.delete(QuoteDetailEntity, {
+        quoteId: dto.id,
+      });
+
+      // 2. Actualizar el total de la cotización
+      await queryRunner.manager.update(
+        QuoteEntity,
+        { id: dto.id },
+        { total: newTotal },
+      );
+
+      // 3. Crear los nuevos detalles
+      const newDetailsToSave = variantsPrice.map((vp) => {
+        return this.quoteDetailRepository.create({
+          quoteId: dto.id,
+          unitPrice: vp.unitPrice,
+          quantity: vp.quantity,
+          clothesVariantId: vp.variantId,
+        });
+      });
+
+      const savedDetails = await queryRunner.manager.save(
+        QuoteDetailEntity,
+        newDetailsToSave,
+      );
+
+      await queryRunner.commitTransaction();
+
+      // 4. Obtener la cotización actualizada con todos sus datos
+      const updatedQuote = await this.quoteRepository.findOne({
+        where: { id: dto.id },
+      });
+
+      return { ...updatedQuote, details: savedDetails };
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      console.error('Error updating quote:', error);
+      throw new BadRequestException('Error updating quote');
+    } finally {
+      await queryRunner.release();
+    }
   }
 
   /**

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -75,7 +75,13 @@ export class QuoteService {
     try {
       const quote = await this.quoteRepository.findOne({
         where: { id },
-        relations: ['customer', 'details', 'details.clothesVariant'],
+        relations: [
+          'customer',
+          'details',
+          'details.clothesVariant',
+          'details.clothesVariant.gender',
+          'details.clothesVariant.size',
+        ],
       });
       if (!quote) {
         throw new NotFoundException(`Quote with ID ${id} not found`);


### PR DESCRIPTION
This PR tightens the quotes workflow and response shapes, and aligns route naming.

I added `UpdateQuoteDTO` plus two thin interfaces—`QuoteSummary` for list views and `CreatedClothes` for create/update responses. `createQuote` and the new `updateQuote` now return a consistent payload with `details`. The update path fully replaces quote details in a single transaction, recalculates the total from current variant prices, and returns the updated aggregate.

Reads are clearer: `getQuoteById` loads the necessary relations (customer, details, variant, gender, size) for a complete view; list endpoints use a dedicated query builder and mapping to deliver `QuoteSummary` with `totalClothes` and `totalUnitsToProduced`. I removed leftover console logs and centralized error handling.

Routes are pluralized for consistency:

* `customer` → `customers`
* `quote` → `quotes`

Customer reference became optional: the DTO uses `@IsOptional()` and the entity column is now nullable.

**API impacts (concise):**

* `POST /quotes` → returns `CreatedClothes` (was `any`).
* `PUT /quotes` → new endpoint for full quote replacement using `UpdateQuoteDTO`.
* `GET /quotes` → returns `QuoteSummary[]` (aggregate list).
* `GET /quotes?status=...` → filtered summaries.
* `GET /quotes/:id` → same path, richer relations.
* `POST /customers` et al now under `/customers` (plural).

**Data model / migration note:** `CustomerEntity.reference` is now nullable; ensure the column allows `NULL` in existing databases.

**Why:** bring the API closer to the use cases in the sales flow (quick list cards vs. full detail view), ensure deterministic updates, and standardize route naming and response contracts.

**How to test (happy path):**

1. Create a quote with two variants; verify the response includes `details` and the computed `total`.
2. Update the same quote with new variant quantities; confirm old details are gone, `total` is recalculated, and returned payload matches `CreatedClothes`.
3. List all quotes and by status; check `totalClothes` and `totalUnitsToProduced` aggregates.
4. Fetch by id; verify relations are present (customer, details → variant, gender, size).
5. Create/update a customer without `reference`; it should pass validation and persist.

No breaking behavior beyond the noted route pluralization and return-type tightening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added endpoints to manage quotes: GET /quotes, GET /quotes/:id, and PUT /quotes to update existing quotes.
  - Quote listings return concise summaries (totals, customer info, total clothes, units to produce).
  - Quote creation/update responses return the created/updated quote with detailed line items.
  - Introduced structured validation for quote updates.

- **Refactor**
  - API routes pluralized: /quote → /quotes and /customer → /customers.
  - Customer reference field is now optional (can be omitted/null).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->