### PR TITLE
docs: mark repository as outdated and provide migration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,49 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="200" alt="Nest Logo" /></a>
-</p>
+# dumi-textile-api (Outdated)
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+> **Status:** ⚠️ This repository is **outdated** and is no longer the primary backend codebase.
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://coveralls.io/github/nestjs/nest?branch=master" target="_blank"><img src="https://coveralls.io/repos/github/nestjs/nest/badge.svg?branch=master#9" alt="Coverage" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## Migration Notice
 
-## Description
+This project has been superseded by:
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+👉 **https://github.com/devEddu17x/telar-backend-api**
 
-## Installation
+Please use the new repository for active development, maintenance, and deployment.
 
-```bash
-$ pnpm install
-```
+---
 
-## Running the app
+## What this repository was
 
-```bash
-# development
-$ pnpm run start
+`dumi-textile-api` is a NestJS (TypeScript) backend API that originally powered core textile platform backend capabilities, including:
 
-# watch mode
-$ pnpm run start:dev
+- REST API services built with **NestJS**
+- Data persistence with **PostgreSQL + TypeORM**
+- Authentication/authorization flows (legacy implementation)
+- Role/permission seeding (RBAC)
+- File handling with **AWS S3**
+- Email sending with **Nodemailer + Handlebars templates**
+- Structured logging with **Pino / NestJS Pino**
+- Unit and E2E testing with **Jest** and Dockerized test DB
 
-# production mode
-$ pnpm run start:prod
-```
+---
 
-## Test
+## Why it is outdated
 
-```bash
-# unit tests
-$ pnpm run test
+The new backend repository introduces new capabilities, including:
+- Modern architecture
+- **Multi-tenant support**
+- Authentication migrated to **AWS Cognito**
+- Improved **CI/CD flows** and delivery pipeline
+- Built for AWS deployment
 
-# e2e tests
-$ pnpm run test:e2e
+For these reasons, this repository is kept only for historical reference.
 
-# test coverage
-$ pnpm run test:cov
-```
+---
 
-## Support
+## For contributors
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](LICENSE).
+- Do **not** try to open new feature PRs in this repo.
+- Do **not** use this repo as integration target for new services.
+- Redirect all new work to:  
+  **https://github.com/devEddu17x/telar-backend-api**
+  


### PR DESCRIPTION
Update README to indicate repository is outdated and redirect to new project.
This pull request updates the `README.md` to clearly indicate that the `dumi-textile-api` repository is outdated and has been superseded by a new backend codebase. The new README provides migration instructions, a summary of what this repository was, reasons for its deprecation, and guidance for contributors.

Repository status and migration notice:

* The README now states that the repository is outdated, points to the new backend repository (`telar-backend-api`), and instructs users to use the new repository for development and maintenance.
* Added sections explaining the purpose of the old repository, reasons for its deprecation (such as the adoption of multi-tenancy and AWS Cognito), and explicit instructions for contributors not to use or contribute to this repository.

Cleanup of legacy content:

* Removed all NestJS branding, badges, and unrelated documentation, replacing them with concise historical and migration information.